### PR TITLE
Persist ROI selection between sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Python project that uses a USB webcam and Tesseract OCR to detect and read tex
 - Dynamic ROI selection with mouse
 - On-screen display of detected text
 - Auto-fade of text after 3 seconds
+- ROI persists between runs via roi.json
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- load ROI from `roi.json` at startup and provide default if missing
- save ROI updates to `roi.json`
- document ROI persistence

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5cdccb420832e98321f2cfda2a39f